### PR TITLE
GroupId from plugin has changed to com.github.mvallerie

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The plugin is deployed in SBT plugins repository, currently, it is a SNAPSHOT ve
 ###project/plugins.sbt
 	resolvers += Resolver.url("sbt-plugin-snapshots", new URL("http://repo.scala-sbt.org/scalasbt/sbt-plugin-snapshots/"))(Resolver.ivyStylePatterns)
 	
-	addSbtPlugin("sbt-scage-plugin" % "sbt-scage-plugin" % "0.1-SNAPSHOT")
+	addSbtPlugin("com.github.mvallerie" % "sbt-scage-plugin" % "0.1-SNAPSHOT")
 ###
 
 ###build.sbt


### PR DESCRIPTION
Hi

When I tried to update this plugin with sbt I got **unresolved dependency** error. After searching for awhile I noticed the sbt-plugin repository had changed. This config worked for me.

regards,
viruch
